### PR TITLE
fixes for the "cat: /proc/<PID>/smaps: No such file or directory" and a drop in memory values issues

### DIFF
--- a/bin/monitor_proc
+++ b/bin/monitor_proc
@@ -3,12 +3,12 @@
 set -eou pipefail
 
 max() {
-    local a="$1"
-    local b="$2"
-    if echo "${a} > ${b}" | bc >/dev/null; then
-        echo "${a}"
+    local a=$1
+    local b=$2
+    if [ "`echo "${a} > ${b}" | bc`" -eq 1 ]; then
+        echo ${a}
     else
-        echo "${b}"
+        echo ${b}
     fi
 }
 
@@ -22,23 +22,29 @@ get_gpu_max_memory_usage() {
         return
     fi
     curr=$(nvidia-smi pmon -s m -c 1 -o T | grep "${my_pid}" | awk '{print $5}' | sort | tail -1 | grep -o "[0-9.]*")
-    max "${curr}" "${max}"
+    max ${curr} ${max}
 }
 
 get_cpu_max_rss_memory_usage() {
     local my_pid=$1
     local max=$2
     local curr
-    curr=$(cat "/proc/${my_pid}/smaps" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
-    max "${curr}" "${max}"
+    local SMAPS_FILE="/proc/${my_pid}/smaps"
+    if [[ -f "${SMAPS_FILE}" ]]; then
+        curr=$(cat "${SMAPS_FILE}" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+        max ${curr} ${max}
+    fi
 }
 
 get_cpu_max_pss_memory_usage() {
     local my_pid=$1
     local max=$2
     local curr
-    curr=$(cat "/proc/${my_pid}/smaps" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
-    max "${curr}" "${max}"
+    local SMAPS_FILE="/proc/${my_pid}/smaps"
+    if [[ -f "${SMAPS_FILE}" ]]; then
+        curr=$(cat "${SMAPS_FILE}" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+        max ${curr} ${max}
+    fi
 }
 
 LOG_FILE=${LOG_FILE:-}
@@ -51,7 +57,7 @@ COMMAND_TO_RUN=$@
 echo "Running  ${COMMAND_TO_RUN} > \"${LOG_FILE}\" 2>&1 &"
 ${COMMAND_TO_RUN} > "${LOG_FILE}" 2>&1 &
 PID_TO_WATCH=$(ps aux |  grep -v 'grep' | grep -F "${COMMAND_TO_RUN}" | grep -v "$0" | awk '{print $2}' | head -1)
-trap "kill -9 ${PID_TO_WATCH}" $(seq 0 15)
+trap "kill -9 ${PID_TO_WATCH} >/dev/null 2>/dev/null" $(seq 0 15)
 MAX_GPU_MEMORY=0
 MAX_RSS_MEMORY=0
 MAX_PSS_MEMORY=0


### PR DESCRIPTION
This PR contains the fixes for the below issues:
https://github.com/seemethere/dotfiles/issues/1
https://github.com/seemethere/dotfiles/issues/2

This PR reduces the frequency of the "cat: /proc/<PID>/smaps: No such file or directory" error message, but doesn't completely eliminate it because of existing potential race condition.