### PR TITLE
Fix for 0 in Max GPU Mem column for non distributed cases

### DIFF
--- a/bin/monitor_proc
+++ b/bin/monitor_proc
@@ -18,7 +18,7 @@ get_gpu_max_memory_usage() {
     local curr
     # Some processes might not use the GPU
     if ! nvidia-smi pmon -s m -c 1 -o T | grep "${my_pid}" >/dev/null 2>/dev/null; then
-        echo "0"
+        echo "${max}"
         return
     fi
     curr=$(nvidia-smi pmon -s m -c 1 -o T | grep "${my_pid}" | awk '{print $5}' | sort | tail -1 | grep -o "[0-9.]*")
@@ -33,6 +33,8 @@ get_cpu_max_rss_memory_usage() {
     if [[ -f "${SMAPS_FILE}" ]]; then
         curr=$(cat "${SMAPS_FILE}" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
         max "${curr}" "${max}"
+    else
+        echo "${max}"
     fi
 }
 
@@ -44,6 +46,8 @@ get_cpu_max_pss_memory_usage() {
     if [[ -f "${SMAPS_FILE}" ]]; then
         curr=$(cat "${SMAPS_FILE}" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
         max "${curr}" "${max}"
+    else
+        echo "${max}"
     fi
 }
 


### PR DESCRIPTION
The script runs fine in distributed case but gives errors in single GPU case. 
It gives 0 under the Max GPU Mem column.
For example the run on mnist example gives the following errors:
Running  python -u main.py --epochs 1 --log-interval 10 > "/tmp/tmp.NUPZLk89DL_monitor_proc" 2>&1 &
Watching PID: 21166
Searching for spawned processes with
Tail log file with: ps --forest -o pid --ppid 21166 --pid 21166 | awk 'NR>1 {print}'
    tail -f /tmp/tmp.NUPZLk89DL_monitor_proc

Max GPU Mem.   Max RSS Mem.   Max PSS Mem.
0              2082.73        1520.48
(standard_in) 2: syntax error
(standard_in) 2: syntax error
(standard_in) 2: syntax error
(standard_in) 2: syntax error
(standard_in) 2: syntax error
(standard_in) 2: syntax error
0
0
This PR has a fix for the 0 in Max GPU Mem column issue and syntax error.