### PR TITLE
Monitor proc script for ROCm

### DIFF
--- a/bin/monitor_proc_rocm
+++ b/bin/monitor_proc_rocm
@@ -5,10 +5,10 @@ set -eou pipefail
 max() {
     local a=$1
     local b=$2
-    if [ "`echo "${a} > ${b}" | bc`" -eq 1 ]; then
-        echo ${a}
+    if (( $(bc <<< "${a}>${b}") )); then
+        echo "${a}"
     else
-        echo ${b}
+        echo "${b}"
     fi
 }
 
@@ -16,14 +16,13 @@ get_gpu_max_memory_usage() {
     local my_pid=$1
     local max=$2
     local curr
-    # Some processes might now use the GPU
+    # Some processes might not use the GPU
     if ! sudo /opt/rocm/bin/rocm-smi --showpidusedmem | grep "${my_pid}" >/dev/null 2>/dev/null; then
-        sleep 1
-        echo "0"
+        echo "${max}"
         return
     fi
     curr=$(sudo /opt/rocm/bin/rocm-smi --showpidusedmem | grep "${my_pid}" | awk '{print $3}' | sort | tail -1 |  grep -o "[0-9.]*")
-    max $(($curr/1000000)) ${max}
+    max "$(($curr/1000000))" "${max}"
 }
 
 get_cpu_max_rss_memory_usage() {
@@ -33,7 +32,9 @@ get_cpu_max_rss_memory_usage() {
     local SMAPS_FILE="/proc/${my_pid}/smaps"
     if [[ -f "${SMAPS_FILE}" ]]; then
         curr=$(cat "${SMAPS_FILE}" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
-        max ${curr} ${max}
+        max "${curr}" "${max}"
+    else
+        echo "${max}"
     fi
 }
 
@@ -44,13 +45,21 @@ get_cpu_max_pss_memory_usage() {
     local SMAPS_FILE="/proc/${my_pid}/smaps"
     if [[ -f "${SMAPS_FILE}" ]]; then
         curr=$(cat "${SMAPS_FILE}" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
-        max ${curr} ${max}
+        max "${curr}" "${max}"
+    else
+        echo "${max}"
     fi
+}
+
+get_multi_proc_ids() {
+    local my_pid=$1
+    # If a process spawns other processes this should catch that
+    ps --forest -o pid --ppid "${my_pid}" --pid "${my_pid}" | awk 'NR>1 {print}'
 }
 
 LOG_FILE=${LOG_FILE:-}
 if [[ -z "${LOG_FILE}" ]]; then
-    LOG_FILE=$(mktemp --suffix "_monitor_proc_rocm")
+    LOG_FILE=$(mktemp --suffix "_monitor_proc")
 fi
 
 COMMAND_TO_RUN=$@
@@ -64,15 +73,18 @@ MAX_RSS_MEMORY=0
 MAX_PSS_MEMORY=0
 
 echo "Watching PID: ${PID_TO_WATCH}"
-echo "Tail log file with: "
+echo "Searching for spawned processes with"
+echo "Tail log file with: ps --forest -o pid --ppid ${PID_TO_WATCH} --pid ${PID_TO_WATCH} | awk 'NR>1 {print}'"
 echo "    tail -f ${LOG_FILE}"
 
 iteration=0
 printf "\n%-15s%-15s%s\n" "Max GPU Mem." "Max RSS Mem." "Max PSS Mem."
 while kill -0 "${PID_TO_WATCH}" >/dev/null 2>/dev/null; do
-    MAX_GPU_MEMORY=$(get_gpu_max_memory_usage "${PID_TO_WATCH}" "${MAX_GPU_MEMORY}")
-    MAX_RSS_MEMORY=$(get_cpu_max_rss_memory_usage "${PID_TO_WATCH}" "${MAX_RSS_MEMORY}")
-    MAX_PSS_MEMORY=$(get_cpu_max_pss_memory_usage "${PID_TO_WATCH}" "${MAX_PSS_MEMORY}")
+    for pid in $(get_multi_proc_ids "${PID_TO_WATCH}"); do
+        MAX_GPU_MEMORY=$(get_gpu_max_memory_usage "${pid}" "${MAX_GPU_MEMORY}")
+        MAX_RSS_MEMORY=$(get_cpu_max_rss_memory_usage "${pid}" "${MAX_RSS_MEMORY}")
+        MAX_PSS_MEMORY=$(get_cpu_max_pss_memory_usage "${pid}" "${MAX_PSS_MEMORY}")
+    done
     # Print out max every 5 seconds
     if [[ "${iteration}" -eq "10" ]]; then
         printf "%-15s%-15s%s\n" "${MAX_GPU_MEMORY}" "${MAX_RSS_MEMORY}" "${MAX_PSS_MEMORY}"

--- a/bin/monitor_proc_rocm
+++ b/bin/monitor_proc_rocm
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+max() {
+    local a="$1"
+    local b="$2"
+    if echo "${a} > ${b}" | bc >/dev/null; then
+        echo "${a}"
+    else
+        echo "${b}"
+    fi
+}
+
+get_gpu_max_memory_usage() {
+    local my_pid=$1
+    local max=$2
+    local curr
+    # Some processes might now use the GPU
+    if ! sudo /opt/rocm/bin/rocm-smi --showpidusedmem | grep "${my_pid}" >/dev/null 2>/dev/null; then
+        sleep 1
+        echo "0"
+        return
+    fi
+    curr=$(sudo /opt/rocm/bin/rocm-smi --showpidusedmem | grep "${my_pid}" | awk '{print $3}' | sort | tail -1 |  grep -o "[0-9.]*")
+    max "$(($curr/1000000))" "${max}"
+}
+
+get_cpu_max_rss_memory_usage() {
+    local my_pid=$1
+    local max=$2
+    local curr
+    curr=$(cat "/proc/${my_pid}/smaps" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+    max "${curr}" "${max}"
+}
+
+get_cpu_max_pss_memory_usage() {
+    local my_pid=$1
+    local max=$2
+    local curr
+    curr=$(cat "/proc/${my_pid}/smaps" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+    max "${curr}" "${max}"
+}
+
+LOG_FILE=${LOG_FILE:-}
+if [[ -z "${LOG_FILE}" ]]; then
+    LOG_FILE=$(mktemp --suffix "_monitor_proc_rocm")
+fi
+
+COMMAND_TO_RUN=$@
+
+echo "Running  ${COMMAND_TO_RUN} > \"${LOG_FILE}\" 2>&1 &"
+${COMMAND_TO_RUN} > "${LOG_FILE}" 2>&1 &
+PID_TO_WATCH=$(ps aux |  grep -v 'grep' | grep -F "${COMMAND_TO_RUN}" | grep -v "$0" | awk '{print $2}' | head -1)
+trap "kill -9 ${PID_TO_WATCH}" $(seq 0 15)
+MAX_GPU_MEMORY=0
+MAX_RSS_MEMORY=0
+MAX_PSS_MEMORY=0
+
+echo "Watching PID: ${PID_TO_WATCH}"
+echo "Tail log file with: "
+echo "    tail -f ${LOG_FILE}"
+
+iteration=0
+printf "\n%-15s%-15s%s\n" "Max GPU Mem." "Max RSS Mem." "Max PSS Mem."
+while kill -0 "${PID_TO_WATCH}" >/dev/null 2>/dev/null; do
+    MAX_GPU_MEMORY=$(get_gpu_max_memory_usage "${PID_TO_WATCH}" "${MAX_GPU_MEMORY}")
+    MAX_RSS_MEMORY=$(get_cpu_max_rss_memory_usage "${PID_TO_WATCH}" "${MAX_RSS_MEMORY}")
+    MAX_PSS_MEMORY=$(get_cpu_max_pss_memory_usage "${PID_TO_WATCH}" "${MAX_PSS_MEMORY}")
+    # Print out max every 5 seconds
+    if [[ "${iteration}" -eq "10" ]]; then
+        printf "%-15s%-15s%s\n" "${MAX_GPU_MEMORY}" "${MAX_RSS_MEMORY}" "${MAX_PSS_MEMORY}"
+        iteration=0
+    else
+        iteration=$((iteration+1))
+    fi
+    sleep 0.5
+done
+printf "%-15s%-15s%s\n" "${MAX_GPU_MEMORY}" "${MAX_RSS_MEMORY}" "${MAX_PSS_MEMORY}"

--- a/bin/monitor_proc_rocm
+++ b/bin/monitor_proc_rocm
@@ -3,12 +3,12 @@
 set -eou pipefail
 
 max() {
-    local a="$1"
-    local b="$2"
-    if echo "${a} > ${b}" | bc >/dev/null; then
-        echo "${a}"
+    local a=$1
+    local b=$2
+    if [ "`echo "${a} > ${b}" | bc`" -eq 1 ]; then
+        echo ${a}
     else
-        echo "${b}"
+        echo ${b}
     fi
 }
 
@@ -23,23 +23,29 @@ get_gpu_max_memory_usage() {
         return
     fi
     curr=$(sudo /opt/rocm/bin/rocm-smi --showpidusedmem | grep "${my_pid}" | awk '{print $3}' | sort | tail -1 |  grep -o "[0-9.]*")
-    max "$(($curr/1000000))" "${max}"
+    max $(($curr/1000000)) ${max}
 }
 
 get_cpu_max_rss_memory_usage() {
     local my_pid=$1
     local max=$2
     local curr
-    curr=$(cat "/proc/${my_pid}/smaps" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
-    max "${curr}" "${max}"
+    local SMAPS_FILE="/proc/${my_pid}/smaps"
+    if [[ -f "${SMAPS_FILE}" ]]; then
+        curr=$(cat "${SMAPS_FILE}" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+        max ${curr} ${max}
+    fi
 }
 
 get_cpu_max_pss_memory_usage() {
     local my_pid=$1
     local max=$2
     local curr
-    curr=$(cat "/proc/${my_pid}/smaps" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
-    max "${curr}" "${max}"
+    local SMAPS_FILE="/proc/${my_pid}/smaps"
+    if [[ -f "${SMAPS_FILE}" ]]; then
+        curr=$(cat "${SMAPS_FILE}" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+        max ${curr} ${max}
+    fi
 }
 
 LOG_FILE=${LOG_FILE:-}
@@ -52,7 +58,7 @@ COMMAND_TO_RUN=$@
 echo "Running  ${COMMAND_TO_RUN} > \"${LOG_FILE}\" 2>&1 &"
 ${COMMAND_TO_RUN} > "${LOG_FILE}" 2>&1 &
 PID_TO_WATCH=$(ps aux |  grep -v 'grep' | grep -F "${COMMAND_TO_RUN}" | grep -v "$0" | awk '{print $2}' | head -1)
-trap "kill -9 ${PID_TO_WATCH}" $(seq 0 15)
+trap "kill -9 ${PID_TO_WATCH} >/dev/null 2>/dev/null" $(seq 0 15)
 MAX_GPU_MEMORY=0
 MAX_RSS_MEMORY=0
 MAX_PSS_MEMORY=0


### PR DESCRIPTION
monitor_proc_rocm script is similar to monitor_proc script. This runs only on ROCm systems. This script works in ROCm3.7 and above version. 


cc: @jithunnair-amd , @sunway513
